### PR TITLE
bug: fixes GET/ hang

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,12 +28,15 @@ class ClientRequest {
 
   async get (requestOptions) {
     return new Promise((resolve, reject) => {
-      requestOptions = generateOptions(requestOptions)
+      requestOptions = generateOptions(requestOptions,
+        {
+          method: 'GET'
+        })
       if (requestOptions.error) reject(requestOptions)
 
       const protocol = requestOptions.protocol.includes('https:') ? https : http
 
-      protocol.get(requestOptions.url, (res) => {
+      const request = protocol.request(requestOptions, (res) => {
         res.setEncoding('utf8')
 
         const { statusCode } = res
@@ -101,6 +104,8 @@ class ClientRequest {
       }).on('error', err => {
         reject(new ReqiError(err, requestOptions))
       })
+
+      request.end('ok')
     })
   }
 


### PR DESCRIPTION
Using `http.request` over `get` helper function.

Adds end call to request.