### PR TITLE
WIP: Stream Support & Best Practices

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,24 +1,20 @@
 'use strict'
 
-const http = require('http')
-const https = require('https')
-
 const ReqiError = require('./error')
 const debug = require('./debug')
+
+const http = require('http')
+const https = require('https')
 
 const {
   header,
   generateOptions
 } = require('./util')
 
-const REQUIRES_DATA = [
-  'PUT',
-  'POST',
-  'PATCH'
-]
-
 class ReqiClient {
   constructor (initOptions) {
+    this.aborted = false
+
     /* default options */
     this.defaults = {
       redirect: false,
@@ -30,93 +26,138 @@ class ReqiClient {
     }
 
     if (!initOptions) initOptions = {}
-    this.reqiOptions = { ...this.defaults, ...initOptions }
+    this.clientOptions = { ...this.defaults, ...initOptions }
   }
 
-  request (requestOptions, data = null) {
+  request (options, requestBody = null) {
+    debug(options)
+    const self = this
     const requestPromise = new Promise((resolve, reject) => {
-      requestOptions = generateOptions(requestOptions)
-
+      const requestOptions = generateOptions(options)
       if (requestOptions.error) reject(requestOptions.error)
 
-      const payload = {
-        statusCode: null,
-        headers: {},
-        body: '',
-        requestOptions,
-        reqiOptions: this.reqiOptions
+      function followRedirect (location) {
+        debug(`redirecting to ${location}`)
+        requestOptions.url = location
+        resolve(self.request(requestOptions))
       }
 
-      const protocol = requestOptions.protocol.includes('https') ? https : http
+      function attemptRetry (retryAfter) {
+        if (retryAfter) {
+          debug('retrying - queuing request')
 
-      const req = protocol.request(requestOptions, (res) => {
+          /* queue retry to event loop */
+          setTimeout(function queueRequest () {
+            resolve(self.request(requestOptions, requestBody))
+          }, retryAfter * 1000 /* seconds to ms */)
+        } else {
+          debug('retrying')
+          resolve(self.request(requestOptions, requestBody))
+        }
+      }
+
+      function parseBody (body) {
+        try {
+          const parsed = JSON.parse(body)
+          return parsed
+        } catch (error) {
+          reject(new ReqiError(error))
+        }
+      }
+
+      const transport = requestOptions.protocol.includes('https:') ? https : http
+      if (requestOptions.agent == null) requestOptions.agent = new transport.Agent(options)
+
+      const req = transport.request(requestOptions)
+
+      req.on('response', (res) => {
         res.setEncoding('utf8')
-        payload.statusCode = res.statusCode
 
-        if (res.headers) payload.headers = { ...payload.headers, ...res.headers }
+        const { statusCode, headers } = res
 
+        let responseBody = ''
         res.on('data', (chunk) => {
-          payload.body += chunk
+          responseBody += chunk
         })
-        res.on('end', () => {
+
+        res.once('end', function responseEnded () {
           if (!res.complete) {
             reject(new ReqiError('Error: response terminated before completion'))
           }
 
-          const location = header(res.headers, 'location')
-          const doRedirect = payload.statusCode >= 300 &&
-                             payload.statusCode < 400 &&
-                             location != null && this.reqiOptions.redirect &&
-                             this.reqiOptions.redirectCount > 0
+          debug(requestOptions.reqCount)
+
+          const { redirect, redirectCount } = self.clientOptions
+          const doRedirect = statusCode >= 300 && statusCode < 400 && redirect && redirectCount > requestOptions.reqCount.redirect
+
           if (doRedirect) {
-            debug(`GET/ redirecting to ${location}`)
-
-            this.reqiOptions.redirectCount--
-            requestOptions.url = location
-            resolve(this.request(requestOptions))
-            return
+            requestOptions.reqCount.redirect++
+            followRedirect(header(res.headers, 'location'))
           }
 
-          const doRetry = this.reqiOptions.retryCodes.includes(+payload.statusCode) &&
-                          this.reqiOptions.retryCount > 0 &&
-                          header(res.headers, 'retry-after') <= this.reqiOptions.maxWait
+          const { retryCodes, retryCount, maxWait } = self.clientOptions
+          const retryAfter = header(headers, 'retry-after')
+          const doRetry = retryCodes.includes(statusCode) && retryCount > requestOptions.reqCount.retry && maxWait >= retryAfter
+
           if (doRetry) {
-            const retryAfter = header(res.headers, 'retry-after')
-            this.reqiOptions.retryCount--
-
-            if (retryAfter) {
-              debug(`GET/ retrying with code ${payload.statusCode} after ~${retryAfter}s have elapsed.`)
-
-              /* queue retry to event loop */
-              setTimeout(() => resolve(this.request(requestOptions, data)), retryAfter * 1e3 /* seconds to ms */)
-            } else {
-              debug(`GET/ retrying with code ${payload.statusCode}`)
-              resolve(this.request(requestOptions, data))
-            }
-            return
+            requestOptions.reqCount.retry++
+            attemptRetry(header(res.headers, 'retry-after'))
           }
 
+          const { parseJSON } = self.clientOptions
           const contentType = header(res.headers, 'content-type')
-          const doParse = this.reqiOptions.parseJSON &&
-                          contentType &&
-                          contentType.includes('application/json')
+          const doParse = parseJSON && contentType && contentType.includes('application/json')
+
           if (doParse) {
-            try {
-              const parsed = JSON.parse(payload.body)
-              payload.body = parsed
-            } catch (error) {
-              reject(new ReqiError('Error: error parsing response payload, returning unparsed payload', payload))
-            }
+            responseBody = parseBody(responseBody)
           }
 
-          resolve(payload)
+          const response = {
+            statusCode,
+            headers,
+            body: responseBody,
+            requestOptions
+          }
+
+          resolve(response)
         })
-      }).on('error', (error) => {
+      })
+
+      req.once('error', function onceError (error) {
+        debug('error making request')
         reject(new ReqiError(error))
       })
 
-      if (data && REQUIRES_DATA.indexOf(requestOptions.method) > 0) {
-        req.write(data)
+      req.once('timeout', function onceTimeout () {
+        debug('request timedout')
+        /* call abort */
+      })
+
+      req.once('abort', function onceAbort () {
+        debug('request aborted')
+        this.aborted = true
+      })
+
+      if (requestBody == null) {
+        requestBody = requestOptions.body
+      }
+
+      if (requestBody != null) {
+        if (requestBody.pipe != null && (typeof requestBody.pipe === 'function')) {
+          debug('request body is a stream')
+          requestBody.pipe(req)
+        } else if (typeof requestBody === 'string' || Buffer.isBuffer(requestBody)) {
+          debug('request body is a buffer')
+          req.write(requestBody)
+        } else {
+          try {
+            debug('request body is a object')
+            const serialized = JSON.stringify(requestBody)
+            req.write(serialized)
+          } catch (error) {
+            reject(new ReqiError(error, requestOptions))
+          }
+        }
       }
 
       req.end()
@@ -125,28 +166,40 @@ class ReqiClient {
     return requestPromise
   }
 
-  async get (requestOptions) {
-    return this.request({ ...requestOptions, method: 'GET' })
+  async get (options) {
+    if (options && typeof options === 'string') options = { url: options }
+
+    return this.request(options)
   }
 
-  async head (requestOptions) {
-    return this.request({ ...requestOptions, method: 'HEAD' })
+  async head (options) {
+    if (options && typeof options === 'string') options = { url: options }
+
+    return this.request({ ...options, method: 'HEAD' })
   }
 
-  async post (requestOptions, data) {
-    return this.request({ ...requestOptions, method: 'POST' }, data)
+  async delete (options) {
+    if (options && typeof options === 'string') options = { url: options }
+
+    return this.request({ ...options, method: 'DELETE' })
   }
 
-  async put (requestOptions, data) {
-    return this.request({ ...requestOptions, method: 'PUT' }, data)
+  async post (options, body = null) {
+    if (options && typeof options === 'string') options = { url: options }
+
+    return this.request({ ...options, method: 'POST' }, body)
   }
 
-  async patch (requestOptions, data) {
-    return this.request({ ...requestOptions, method: 'PATCH' }, data)
+  async put (options, body = null) {
+    if (options && typeof options === 'string') options = { url: options }
+
+    return this.request({ ...options, method: 'PUT' }, body)
   }
 
-  async delete (requestOptions) {
-    return this.request({ ...requestOptions, method: 'DELETE' })
+  async patch (options, body = null) {
+    if (options && typeof options === 'string') options = { url: options }
+
+    return this.request({ ...options, method: 'PATCH' }, body)
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,34 +17,42 @@ function header (headers, field) {
   return headers[field]
 }
 
-function generateOptions (requestOptions, addons) {
-  if (requestOptions && typeof requestOptions === 'string') {
-    requestOptions = { url: requestOptions }
-  }
-
-  if (!requestOptions || !requestOptions.url) {
-    return { ...requestOptions, error: new ReqiError('Error: options.url is required.', requestOptions) }
-  }
-
-  if (addons && typeof addons === 'object' && addons.constructor === Object) {
-    requestOptions = { ...requestOptions, ...addons }
+function generateOptions (opts) {
+  if (!opts.url) {
+    return { ...opts, error: new ReqiError('Error: url unspecified.') }
   }
 
   let url
   try {
-    url = new URL(requestOptions.url)
+    url = new URL(opts.url)
   } catch (error) {
-    return { ...requestOptions, error: new ReqiError('Error: invalid URL (options.url).', requestOptions) }
+    return { ...opts, error: new ReqiError(error) }
   }
 
+  const protocol = url.protocol
+  const method = opts.method || 'GET' /* defaults to GET request */
+  const u = opts.url
+  const host = url.host
+  const port = Number(url.port) || (protocol === 'https:' ? 443 : 80)
+  const path = url.pathname || ''
+  const headers = { ...opts.headers } || {}
+  const reqCount = (opts.reqCount == null) ? { retry: 0, redirect: 0 } : opts.reqCount
+  const id = 1
+
   const options = {
-    ...requestOptions,
-    origin: url.origin,
-    hostname: url.hostname,
-    port: url.port,
-    path: url.pathname,
-    protocol: url.protocol
+    protocol,
+    method,
+    url: u,
+    host,
+    port,
+    path,
+    headers,
+    agent: opts.agent,
+    reqCount,
+    id
   }
+
+  debug(options)
 
   return options
 }


### PR DESCRIPTION
 refactor:
f6695cf

- once listener for abort, timeout, and error
- generateOptions reformat
- clientOptions is no longer mutated
- support for stream req bodies

